### PR TITLE
Add support for bson crate's ObjectId as a Scalar, so that GraphQL in…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["network-programming", "asynchronous"]
 readme = "README.md"
 
 [features]
-default = ["chrono", "uuid", "url"]
+default = ["bson", "chrono", "uuid", "url"]
 
 [dependencies]
 async-graphql-derive = { path = "async-graphql-derive", version = "1.3.2" }
@@ -30,6 +30,7 @@ bytes = "0.5.4"
 Inflector = "0.11.4"
 base64 = "0.12.0"
 byteorder = "1.3.4"
+bson = { version = "0.14.1", optional = true }
 chrono = { version = "0.4.10", optional = true }
 uuid = { version = "0.8.1", optional = true }
 url = { version = "2.1.1", optional = true }

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Open `http://localhost:8000` in browser
         - [X] DateTime
         - [X] UUID
         - [X] Url
+        - [X] ObjectId
     - [X] Containers 
         - [X] List
         - [X] Non-Null

--- a/src/scalars/bson.rs
+++ b/src/scalars/bson.rs
@@ -1,0 +1,21 @@
+use crate::{impl_scalar_internal, Scalar, Result, Value};
+use bson::oid::ObjectId;
+
+impl Scalar for ObjectId {
+    fn type_name() -> &'static str {
+        "ObjectId"
+    }
+
+    fn parse(value: &Value) -> Option<Self> {
+        match value {
+            Value::String(s) => Some(ObjectId::with_string(&s).ok()?),
+            _ => None,
+        }
+    }
+
+    fn to_json(&self) -> Result<serde_json::Value> {
+        Ok(self.to_string().into())
+    }
+}
+
+impl_scalar_internal!(ObjectId);

--- a/src/scalars/mod.rs
+++ b/src/scalars/mod.rs
@@ -9,6 +9,8 @@ mod url;
 mod datetime;
 #[cfg(feature = "uuid")]
 mod uuid;
+#[cfg(feature = "bson")]
+mod bson;
 
 pub use id::ID;
 
@@ -18,6 +20,7 @@ mod tests {
     use crate::Type;
     use chrono::{DateTime, Utc};
     use uuid::Uuid;
+    use bson::oid::ObjectId;
 
     #[test]
     fn test_scalar_type() {
@@ -52,6 +55,12 @@ mod tests {
         {
             assert_eq!(<Uuid as Type>::type_name(), "UUID");
             assert_eq!(<Uuid as Type>::qualified_type_name(), "UUID!");
+        }
+
+        #[cfg(feature = "bson")]
+        {
+            assert_eq!(<ObjectId as Type>::type_name(), "ObjectId");
+            assert_eq!(<ObjectId as Type>::qualified_type_name(), "ObjectId!");
         }
     }
 }


### PR DESCRIPTION
…tegration with MongoDB becomes possible.