### PR TITLE
ExtendedError and ResultExt inital draft

### DIFF
--- a/examples/error_extensions.rs
+++ b/examples/error_extensions.rs
@@ -1,0 +1,108 @@
+use actix_rt;
+use actix_web::{guard, web, App, HttpResponse, HttpServer};
+use async_graphql::http::{graphiql_source, playground_source, GQLRequest, GQLResponse};
+use async_graphql::*;
+use serde_json::json;
+
+#[derive(Debug)]
+pub enum MyError {
+    NotFound,
+    ServerError(String),
+    ErrorWithoutExtensions,
+}
+
+// Let's implement a mapping from our MyError to async_graphql::Error (anyhow::Error).
+// But instead of mapping to async_graphql::Error directly we map to async_graphql::ExtendedError,
+// which gives us the opportunity to provide custom extensions to our errors.
+// Note: Values which can't get serialized to JSON-Objects simply get ignored.
+impl From<MyError> for Error {
+    fn from(my_error: MyError) -> Error {
+        match my_error {
+            MyError::NotFound => {
+                let msg = "Could not find ressource".to_owned();
+                let extensions = json!({"code": "NOT_FOUND"});
+                ExtendedError(msg, extensions).into()
+            }
+            MyError::ServerError(reason) => {
+                ExtendedError("ServerError".to_owned(), json!({ "reason": reason })).into()
+            }
+
+            MyError::ErrorWithoutExtensions => ExtendedError(
+                "No Extensions".to_owned(),
+                json!("This will be ignored since it does not represent an object."),
+            )
+            .into(),
+        }
+    }
+}
+
+fn get_my_error() -> std::result::Result<String, MyError> {
+    Err(MyError::ServerError("The database is locked".to_owned()))
+}
+
+struct QueryRoot {}
+
+#[Object]
+impl QueryRoot {
+    #[field]
+    async fn do_not_find(&self) -> Result<i32> {
+        Err(MyError::NotFound)?
+    }
+
+    #[field]
+    async fn fail(&self) -> Result<String> {
+        Ok(get_my_error()?)
+    }
+
+    #[field]
+    async fn without_extensions(&self) -> Result<String> {
+        Err(MyError::ErrorWithoutExtensions)?
+    }
+
+    // Using the ResultExt trait, we can attach extensions on the fly capturing the execution
+    // environment. This method works on foreign types as well. The trait is implemented for all
+    // Results where the error variant implements Display.
+    #[field]
+    async fn parse_value(&self, val: String) -> Result<i32> {
+        val.parse().extend_err(|err| {
+            json!({ "description": format!("Could not parse value {}: {}", val, err) })
+        })
+    }
+}
+
+async fn index(
+    s: web::Data<Schema<QueryRoot, EmptyMutation, EmptySubscription>>,
+    req: web::Json<GQLRequest>,
+) -> web::Json<GQLResponse> {
+    web::Json(req.into_inner().execute(&s).await)
+}
+
+async fn gql_playgound() -> HttpResponse {
+    HttpResponse::Ok()
+        .content_type("text/html; charset=utf-8")
+        .body(playground_source("/", None))
+}
+
+async fn gql_graphiql() -> HttpResponse {
+    HttpResponse::Ok()
+        .content_type("text/html; charset=utf-8")
+        .body(graphiql_source("/"))
+}
+
+#[actix_rt::main]
+async fn main() -> std::io::Result<()> {
+    HttpServer::new(move || {
+        App::new()
+            .data(Schema::new(QueryRoot {}, EmptyMutation, EmptySubscription))
+            .service(web::resource("/").guard(guard::Post()).to(index))
+            .service(web::resource("/").guard(guard::Get()).to(gql_playgound))
+            .service(
+                web::resource("/graphiql")
+                    .guard(guard::Get())
+                    .to(gql_graphiql),
+            )
+    })
+    .bind("127.0.0.1:8000")?
+    .run()
+    .await
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,9 @@ pub mod http;
 
 pub use base::{Scalar, Type};
 pub use context::{Context, QueryPathSegment, Variables};
-pub use error::{ErrorWithPosition, PositionError, QueryError, QueryParseError};
+pub use error::{
+    ErrorWithPosition, ExtendedError, PositionError, QueryError, QueryParseError, ResultExt,
+};
 pub use graphql_parser::query::Value;
 pub use query::{PreparedQuery, QueryBuilder, QueryResult};
 pub use registry::CacheControl;


### PR DESCRIPTION
My first draft on implementing extensions to errors which should resolve #9. Example needs some cleanup and documentation. Tests are also not complete. This is more about discussing the general idea and the provided interface for the users. I had to drop the original idea of a simple trait because without specialization-feature [RFC 1210](https://github.com/rust-lang/rust/issues/31844#) it would get really hacky to implement user overwriteable methods.

Instead I used the wrapper approach like `PositionError` plus an additional convenience trait on the `std::Result`. 

Have you considered replacing the re-exported anyhow::Error type with some custom error you are in control of? I think this could simplify the overall error-handling code a little bit.
