### PR TITLE
Add failing interface test

### DIFF
--- a/tests/interface.rs
+++ b/tests/interface.rs
@@ -161,3 +161,83 @@ pub async fn test_multiple_interfaces() {
         })
     );
 }
+
+#[async_std::test]
+pub async fn test_multiple_objects_in_multiple_interfaces() {
+    struct MyObjOne;
+
+    #[async_graphql::Object]
+    impl MyObjOne {
+        #[field]
+        async fn value_a(&self) -> i32 {
+            1
+        }
+
+        #[field]
+        async fn value_b(&self) -> i32 {
+            2
+        }
+
+        #[field]
+        async fn value_c(&self) -> i32 {
+            3
+        }
+    }
+
+    struct MyObjTwo;
+
+    #[async_graphql::Object]
+    impl MyObjTwo {
+        #[field]
+        async fn value_a(&self) -> i32 {
+            1
+        }
+    }
+
+    #[async_graphql::Interface(field(name = "value_a", type = "i32"))]
+    struct InterfaceA(MyObjOne, MyObjTwo);
+
+    #[async_graphql::Interface(field(name = "value_b", type = "i32"))]
+    struct InterfaceB(MyObjOne);
+
+    struct Query;
+
+    #[Object]
+    impl Query {
+        #[field]
+        async fn my_obj(&self) -> Vec<InterfaceA> {
+            vec![MyObjOne.into(), MyObjTwo.into()]
+        }
+    }
+
+    let schema = Schema::build(Query, EmptyMutation, EmptySubscription)
+        .register_type::<InterfaceB>() // `InterfaceA` is not directly referenced, so manual registration is required.
+        .finish();
+    let query = format!(
+        r#"{{
+            myObj {{
+               ... on InterfaceA {{
+                valueA
+              }}
+              ... on InterfaceB {{
+                valueB
+              }}
+              ... on MyObjOne {{
+                valueC
+              }}
+            }}
+        }}"#
+    );
+    assert_eq!(
+        schema.execute(&query).await.unwrap().data,
+        serde_json::json!({
+            "myObj": [{
+                "valueA": 1,
+                "valueB": 2,
+                "valueC": 3,
+            }, {
+                "valueA": 1
+            }]
+        })
+    );
+}


### PR DESCRIPTION
I'm adding a failing test for Interfaces resolvers being applied when an Object doesn't belong to it.

I just ran into this in my project and I believe this is the smaller version.