### PR TITLE
Add bson::UtcDateTime support

### DIFF
--- a/src/scalars/bson.rs
+++ b/src/scalars/bson.rs
@@ -1,5 +1,6 @@
 use crate::{impl_scalar_internal, Result, Scalar, Value};
-use bson::oid::ObjectId;
+use bson::{oid::ObjectId, UtcDateTime};
+use chrono::{DateTime, Utc};
 
 impl Scalar for ObjectId {
     fn type_name() -> &'static str {
@@ -19,3 +20,19 @@ impl Scalar for ObjectId {
 }
 
 impl_scalar_internal!(ObjectId);
+
+impl Scalar for UtcDateTime {
+    fn type_name() -> &'static str {
+        "DateTime"
+    }
+
+    fn parse(value: &Value) -> Option<Self> {
+        DateTime::<Utc>::parse(value).map(UtcDateTime::from)
+    }
+
+    fn to_json(&self) -> Result<serde_json::Value> {
+        (**self).to_json()
+    }
+}
+
+impl_scalar_internal!(UtcDateTime);


### PR DESCRIPTION
Simple support for [bson::UtcDateTime](https://docs.rs/bson/0.14.1/bson/struct.UtcDateTime.html) as scalar.